### PR TITLE
Fix markdown for 'hidden field' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We've looked at setting up the associations behind posts with comments, categori
     * The title, categories, and content of the post.
     * All of the comments associated with the post.
     * A list of all the unique users who have commented on the post. A user's name should only show up once in this section, even if they've commented multiple times.
-    * A form to add a new comment. The form should have a drop-down menu to select a user (we'll change this in future lessons to automatically associate the comment with a logged-in user). We should also be able to create a new user here and automatically associate it with the post. To associate a new comment with a post, you'll have to use a _[hidden field](https://apidock.com/rails/ActionView/Helpers/FormHelper/hidden_field)_:
+    * A form to add a new comment. The form should have a drop-down menu to select a user (we'll change this in future lessons to automatically associate the comment with a logged-in user). We should also be able to create a new user here and automatically associate it with the post. To associate a new comment with a post, you'll have to use a [hidden field](https://apidock.com/rails/ActionView/Helpers/FormHelper/hidden_field):
 
   ```erb
   <%= f.hidden_field :post_id, value: @post.id %>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,7 @@
 class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
+    @users = @post.users.distinct
   end
 
   def index

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,6 @@
 class Category < ActiveRecord::Base
   has_many :post_categories
   has_many :posts, through: :post_categories
+
+  
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,5 @@
 class Comment < ActiveRecord::Base
   belongs_to :user
   belongs_to :post
-
+  accepts_nested_attributes_for :user, reject_if: :all_blank
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,5 +4,19 @@ class Post < ActiveRecord::Base
   has_many :comments
   has_many :users, through: :comments
 
+  # def categories_attributes=(category_attributes)
+  #   category_attributes.values.each do |category_attribute|
+  #     category = Category.find_or_create_by(category_attribute)
+  #     self.post_categories.build(category: category)
+  #   end
+  # end
 
+  def categories_attributes=(category_attributes)
+    category_attributes.values.each do |category_attribute|
+      if category_attribute["name"].present?
+        category = Category.find_or_create_by(category_attribute)
+        self.categories << category
+      end
+    end
+  end
 end

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Posts in category: <%= @category.name %></h1>
+
+<% @category.posts.each do |post| %>
+    <p>
+        <%= link_to post.title, post_path(post) %>
+    </p>
+<% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,1 +1,28 @@
+<h1>Create a NEW Post</h1>
 
+<%= form_for post do |f| %>
+    <p> 
+        <%= f.label :title, "Post Title: " %>
+        <%= f.text_field :title %>
+    </p>
+
+    <p>
+        <%= f.label :content, "Post Content: " %>
+        <%= f.text_area :content %>
+    </p>
+
+    <h3>Select Post Categories</h3>
+
+    <p>
+        <%= f.collection_check_boxes :category_ids, Category.all, :id, :name %>
+    </p>
+
+    <p>
+        <%= f.fields_for :categories, post.categories.build do |ff| %>
+        <%= ff.label :name, "Create a New Category" %>
+        <%= ff.text_field :name %>
+        <% end %>
+    </p>
+    <br />
+    <%= f.submit %>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,1 +1,40 @@
+<h1><%= @post.title %></h1>
+<h4>Categories: 
+    <%= @post.categories.map(&:name).join(' ') %>
+</h4>
+<p>
+    <%= @post.content %>
+</p>
+
+<h3>Comments</h3>
+<ul>
+    <% @users.each do |user| %>
+        <%= link_to user.username, user %> says: <br />
+        <% user.comments.each do |comment|%>
+            <%= comment.content %><br>
+        <% end %>
+    <% end %>
+</ul>
+
+<h3>New Comments</h3>
+<%= form_for @post.comments.build do |f| %>
+    <%= f.hidden_field :post_id, value: @post.id %>
+    <p>
+        <%= f.collection_select :user_id, User.all, :id, :username %><br><br>
+    </p>
+
+    <%= f.fields_for :user, User.new do |ff| %>
+        <%= ff.label :username %>
+        <%= ff.text_field :username %>
+    <% end %>
+
+    <p>
+        <%= f.label :content, "New Comment" %><br>
+        <%= f.text_area :content %>
+    </p>
+    
+    <br/>
+    <%= f.submit %>
+<% end %>
+
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,1 +1,9 @@
+<h1><%= @user.username %></h1>
 
+<h4>Comments</h4>
+
+<% @user.posts.each do |post|%>
+    <p>
+        <%= link_to post.title, post_path(post) %>
+    </p>
+<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -25,20 +24,18 @@ ActiveRecord::Schema.define(version: 20160119152016) do
     t.integer  "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_comments_on_post_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
-
-  add_index "comments", ["post_id"], name: "index_comments_on_post_id"
-  add_index "comments", ["user_id"], name: "index_comments_on_user_id"
 
   create_table "post_categories", force: :cascade do |t|
     t.integer  "post_id"
     t.integer  "category_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["category_id"], name: "index_post_categories_on_category_id"
+    t.index ["post_id"], name: "index_post_categories_on_post_id"
   end
-
-  add_index "post_categories", ["category_id"], name: "index_post_categories_on_category_id"
-  add_index "post_categories", ["post_id"], name: "index_post_categories_on_post_id"
 
   create_table "posts", force: :cascade do |t|
     t.string   "title"


### PR DESCRIPTION
The markdown syntax for italics does not render on Learn.co as intended. The link renders correctly and is italicized on GitHub but on Learn.co the italic markdown syntax is breaking the link and is rendering incorrectly.

Picture of link on Learn.co:

<img width="433" alt="Screen Shot 2020-01-26 at 1 19 23 PM" src="https://user-images.githubusercontent.com/49502059/73139743-2b317400-403f-11ea-885f-d77caae647ba.png">

Picture of link on GitHub:

<img width="512" alt="Screen Shot 2020-01-26 at 1 19 36 PM" src="https://user-images.githubusercontent.com/49502059/73139760-469c7f00-403f-11ea-8ddd-e8bbc37259ba.png">

Removing the italic markdown will correct the link improperly rendering on Learn.co

